### PR TITLE
fix: api changes on completion-nvim side

### DIFF
--- a/after/plugin/vim_dadbod_completion.vim
+++ b/after/plugin/vim_dadbod_completion.vim
@@ -1,2 +1,2 @@
-lua has_source,source = pcall(require, 'source')
-lua if has_source then source.addCompleteItems('vim-dadbod-completion', require'vim_dadbod_completion'.complete_item) end
+lua has_completion,completion = pcall(require, 'completion')
+lua if has_completion then completion.addCompletionSource('vim-dadbod-completion', require'vim_dadbod_completion'.complete_item) end


### PR DESCRIPTION
Just a small changes on completion-nvim side. I'm planning moving source.lua to subdirectory and use completion.lua as the main api, so before merging that to master I want to make sure your plugin doesn't just break because of it.
Reference: haorenW1025/completion-nvim#121
Note: I haven't tested it on my side cause I know nothing about vim-dadbod.