### PR TITLE
Improved Oracle Support

### DIFF
--- a/autoload/vim_dadbod_completion.vim
+++ b/autoload/vim_dadbod_completion.vim
@@ -185,7 +185,7 @@ function! s:generate_query(db, query_key, ...) abort
   if a:0 > 0
     let Query = Query(a:1)
   endif
-  return printf('%s %s', base_query, Query)
+  return db#url#parse(a:db).scheme ==? 'oracle' ? printf('%s %s', Query, base_query) : printf('%s %s', base_query, Query)
 endfunction
 
 function! s:count_columns_and_cache(db, count) abort

--- a/autoload/vim_dadbod_completion/schemas.vim
+++ b/autoload/vim_dadbod_completion/schemas.vim
@@ -24,11 +24,11 @@ let s:postgres = {
       \ }
 
 let s:oracle_args = "echo \"SET linesize 4000;\nSET pagesize 4000;\n%s\" | "
-let s:oracle_base_column_query = "COLUMN column_name FORMAT a50;\nCOLUMN table_name FORMAT a50;\nSELECT C.table_name, C.column_name FROM all_tab_columns C, all_users U WHERE C.owner = U.username AND U.common = 'NO' %s;"
+let s:oracle_base_column_query = "COLUMN column_name FORMAT a50;\nCOLUMN table_name FORMAT a50;\nSELECT C.table_name, C.column_name FROM all_tab_columns C JOIN all_users U ON C.owner = U.username WHERE U.common = 'NO' %s;"
 let s:oracle = {
 \   'column_parser': function('s:map_and_filter', ['\s\s\+']),
 \   'column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, 'ORDER BY C.column_name ASC')),
-\   'count_column_query': printf(s:oracle_args, "COLUMN total FORMAT 9999999;\nSELECT COUNT(*) AS total FROM all_tab_columns C, all_users U WHERE C.owner = U.username AND U.common = 'NO';"),
+\   'count_column_query': printf(s:oracle_args, "COLUMN total FORMAT 9999999;\nSELECT COUNT(*) AS total FROM all_tab_columns C JOIN all_users U ON C.owner = U.username WHERE U.common = 'NO';"),
 \   'count_parser': function('s:count_parser', [1]),
 \   'quote': 1,
 \   'table_column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, "AND C.table_name='{db_tbl_name}'")),

--- a/autoload/vim_dadbod_completion/schemas.vim
+++ b/autoload/vim_dadbod_completion/schemas.vim
@@ -28,7 +28,7 @@ let s:oracle_base_column_query = "COLUMN column_name FORMAT a50;\nCOLUMN table_n
 let s:oracle = {
 \   'column_parser': function('s:map_and_filter', ['\s\s\+']),
 \   'column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, 'ORDER BY column_name ASC')),
-\   'count_column_query': printf(s:oracle_args, "COLUMN Total FORMAT 9999999;\nSELECT COUNT(*) AS Total FROM all_tab_columns;"),
+\   'count_column_query': printf(s:oracle_args, "COLUMN total FORMAT 9999999;\nSELECT COUNT(*) AS total FROM all_tab_columns;"),
 \   'count_parser': function('s:count_parser', [1]),
 \   'quote': 1,
 \   'table_column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, 'WHERE table_name={db_tbl_name}')),

--- a/autoload/vim_dadbod_completion/schemas.vim
+++ b/autoload/vim_dadbod_completion/schemas.vim
@@ -24,14 +24,14 @@ let s:postgres = {
       \ }
 
 let s:oracle_args = "echo \"SET linesize 4000;\nSET pagesize 4000;\n%s\" | "
-let s:oracle_base_column_query = "COLUMN column_name FORMAT a50;\nCOLUMN table_name FORMAT a50;\nSELECT C.table_name, C.column_name FROM all_tab_columns C JOIN all_users U ON C.owner = U.username WHERE U.common = 'NO' %s;"
+let s:oracle_base_column_query = printf(s:oracle_args, "COLUMN column_name FORMAT a50;\nCOLUMN table_name FORMAT a50;\nSELECT C.table_name, C.column_name FROM all_tab_columns C JOIN all_users U ON C.owner = U.username WHERE U.common = 'NO' %s;")
 let s:oracle = {
 \   'column_parser': function('s:map_and_filter', ['\s\s\+']),
-\   'column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, 'ORDER BY C.column_name ASC')),
+\   'column_query': printf(s:oracle_base_column_query, 'ORDER BY C.column_name ASC'),
 \   'count_column_query': printf(s:oracle_args, "COLUMN total FORMAT 9999999;\nSELECT COUNT(*) AS total FROM all_tab_columns C JOIN all_users U ON C.owner = U.username WHERE U.common = 'NO';"),
 \   'count_parser': function('s:count_parser', [1]),
 \   'quote': 1,
-\   'table_column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, "AND C.table_name='{db_tbl_name}'")),
+\   'table_column_query': {table -> printf(s:oracle_base_column_query, "AND C.table_name='".table."'")},
 \ }
 
 let s:schemas = {

--- a/autoload/vim_dadbod_completion/schemas.vim
+++ b/autoload/vim_dadbod_completion/schemas.vim
@@ -23,6 +23,17 @@ let s:postgres = {
       \ 'count_parser': function('s:count_parser', [1])
       \ }
 
+let s:oracle_args = "echo \"SET linesize 4000;\nSET pagesize 4000;\n%s\" | "
+let s:oracle_base_column_query = "COLUMN column_name FORMAT a50;\nCOLUMN table_name FORMAT a50;\nSELECT table_name, column_name FROM all_tab_columns %s;"
+let s:oracle = {
+\   'column_parser': function('s:map_and_filter', ['\s\s\+']),
+\   'column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, 'ORDER BY column_name ASC')),
+\   'count_column_query': printf(s:oracle_args, "COLUMN Total FORMAT 9999999;\nSELECT COUNT(*) AS Total FROM all_tab_columns;"),
+\   'count_parser': function('s:count_parser', [1]),
+\   'quote': 1,
+\   'table_column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, 'WHERE table_name={db_tbl_name}')),
+\ }
+
 let s:schemas = {
       \ 'postgres': s:postgres,
       \ 'postgresql': s:postgres,
@@ -34,6 +45,7 @@ let s:schemas = {
       \   'column_parser': function('s:map_and_filter', ['\t']),
       \   'count_parser': function('s:count_parser', [1])
       \ },
+      \ 'oracle': s:oracle,
       \ 'sqlserver': {
       \   'column_query': printf('-h-1 -W -s "|" -Q "%s"', s:query),
       \   'count_column_query': printf('-h-1 -W -Q "%s"', s:count_query),

--- a/autoload/vim_dadbod_completion/schemas.vim
+++ b/autoload/vim_dadbod_completion/schemas.vim
@@ -24,14 +24,14 @@ let s:postgres = {
       \ }
 
 let s:oracle_args = "echo \"SET linesize 4000;\nSET pagesize 4000;\n%s\" | "
-let s:oracle_base_column_query = "COLUMN column_name FORMAT a50;\nCOLUMN table_name FORMAT a50;\nSELECT table_name, column_name FROM all_tab_columns %s;"
+let s:oracle_base_column_query = "COLUMN column_name FORMAT a50;\nCOLUMN table_name FORMAT a50;\nSELECT C.table_name, C.column_name FROM all_tab_columns C, all_users U WHERE C.owner = U.username AND U.common = 'NO' %s;"
 let s:oracle = {
 \   'column_parser': function('s:map_and_filter', ['\s\s\+']),
-\   'column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, 'ORDER BY column_name ASC')),
-\   'count_column_query': printf(s:oracle_args, "COLUMN total FORMAT 9999999;\nSELECT COUNT(*) AS total FROM all_tab_columns;"),
+\   'column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, 'ORDER BY C.column_name ASC')),
+\   'count_column_query': printf(s:oracle_args, "COLUMN total FORMAT 9999999;\nSELECT COUNT(*) AS total FROM all_tab_columns C, all_users U WHERE C.owner = U.username AND U.common = 'NO';"),
 \   'count_parser': function('s:count_parser', [1]),
 \   'quote': 1,
-\   'table_column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, 'WHERE table_name={db_tbl_name}')),
+\   'table_column_query': printf(s:oracle_args, printf(s:oracle_base_column_query, "AND C.table_name='{db_tbl_name}'")),
 \ }
 
 let s:schemas = {


### PR DESCRIPTION
I'm opening this pull to go along with kristijanhusak/vim-dadbod-ui#68. This PR adds first-class support for Oracle databases to this plugin.

So far, I can make this implementation work inconsistently. There something wrong and I don't know what yet; it's either the amount of time required to do the queries and cache the completion, or some sequence of events which make it work. I'm going to keep digging while the other PR is looked over.

Here it is working:

![Completion](https://user-images.githubusercontent.com/36409591/98596171-0f811c80-22a5-11eb-9d1b-fd68c7c4334a.png)
