### PR TITLE
Consider more options when looking for DB url

### DIFF
--- a/autoload/vim_dadbod_completion.vim
+++ b/autoload/vim_dadbod_completion.vim
@@ -388,10 +388,13 @@ function! s:get_buffer_db_info(bufnr) abort
           \ }
   endif
 
-  let db = getbufvar(a:bufnr, 'db')
-  if empty(db)
-    let db = get(g:, 'db', '')
-  endif
+  let db = $DATABASE_URL
+  for dict in [w:, t:, b:, g:]
+    if has_key(dict, 'db') && !empty(dict.db)
+      let db = dict.db
+      break
+    endif
+  endfor
   if !empty(db)
     call vim_dadbod_completion#utils#msg('Connecting to db...')
     let db = db#connect(db#resolve(db))

--- a/doc/vim-dadbod-completion.txt
+++ b/doc/vim-dadbod-completion.txt
@@ -93,7 +93,7 @@ FEATURES                                          *vim-dadbod-completion-feature
 HOW IT WORKS                                  *vim-dadbod-completion-how_it_works*
 
 *   If an sql buffer is created by vim-dadbod-ui (https://github.com/kristijanhusak/vim-dadbod-ui), it reads all the configuration from there. It should work out of the box.
-*   If `vim-dadbod-ui` is not used, vim-dadbod (https://github.com/tpope/vim-dadbod) `g:db` or `b:db` is used. If you want, you can also add `b:db_table` to limit autocompletions to that table only.
+*   If `vim-dadbod-ui` is not used, vim-dadbod (https://github.com/tpope/vim-dadbod) environment variable `$DATABASE_URL` or `w:db`, `t:db`, `b:db`, `g:db` used, whichever is found first. If you want, you can also add `b:db_table` to limit autocompletions to that table only.
 
 --------------------------------------------------------------------------------
 SETTINGS                                          *vim-dadbod-completion-settings*


### PR DESCRIPTION
Adjust the places and search order of DB URL to match [vim-dadbod order](https://github.com/tpope/vim-dadbod/blob/389a2b0120f82b13d51ff7c07f5c13f9bc9f412f/autoload/db.vim#L20-L29), also updated the documentation to reflect this change.

Originally, I stumbled on the case when completions where not working when environment variable `$DATABASE_URL` was set, but I also added the other missing `w:db` and `t:db` as well.