### PR TITLE
Update the README with info about the required SQLite version

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ let g:completion_matching_ignore_case = 1
 
 ## Features
 * Autocomplete table names, with automatic quoting where needed. Works for all schemes that [vim-dadbod](https://github.com/tpope/vim-dadbod) supports.
-* Autocomplete table columns, context aware. Also knows to read aliases (`select * from mytable tbl where tbl.id = 1`). Currently works for `PostgreSQL`, `MySQL`, `Oracle`, `SQLite` and `SQLserver/MSSQL`.
+* Autocomplete table columns, context aware. Also knows to read aliases (`select * from mytable tbl where tbl.id = 1`). Currently works for `PostgreSQL`, `MySQL`, `Oracle`, `SQLite` (requires version `3.37.0 (2021-11-27)`) and `SQLserver/MSSQL`.
 * Out of the box integration with [vim-dadbod-ui](https://github.com/kristijanhusak/vim-dadbod-ui)
 
 ## How it works

--- a/doc/vim-dadbod-completion.txt
+++ b/doc/vim-dadbod-completion.txt
@@ -86,7 +86,7 @@ For `deoplete`, `completion-nvim`, `nvim-compe`, `ddc` and `omnifunc`, install i
 FEATURES                                          *vim-dadbod-completion-features*
 
 *   Autocomplete table names, with automatic quoting where needed. Works for all schemes that vim-dadbod (https://github.com/tpope/vim-dadbod) supports.
-*   Autocomplete table columns, context aware. Also knows to read aliases (). Currently works for `PostgreSQL`, `MySQL`, `Oracle` and `SQLserver/MSSQL`.
+*   Autocomplete table columns, context aware. Also knows to read aliases (). Currently works for `PostgreSQL`, `MySQL`, `Oracle`, `SQLite` (requires version `3.37.0 (2021-11-27)`) and `SQLserver/MSSQL`.
 *   Out of the box integration with vim-dadbod-ui (https://github.com/kristijanhusak/vim-dadbod-ui)
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This plugin uses the pragma `table_list` for getting info about the columns, and [`PRAGMA table_list` was introduced in SQLite version `3.37.0 (2021-11-27)`](https://www.sqlite.org/pragma.html#pragma_table_list).

https://github.com/kristijanhusak/vim-dadbod-completion/blob/fc7321a17f4c55db11fae89a884ddf4724020bae/autoload/vim_dadbod_completion/schemas.vim#L89

I discovered this when I was investigating why the autocompletion for the columns was broken for me. Eventually I found the issue through the source code, but I think it would be helpful for others to mention this piece of information in the `README.md` + docs too, so I added it in this PR. What do you think?

P.S.: This plugin is phenomenal. It makes me so much faster! Vim-motion + vim-regex = magic! Thank you for creating this. ☺️
