### PR TITLE
Use SVV_COLUMNS Instead of INFORMATION_SCHEMA.COLUMNS On Redshift

### DIFF
--- a/autoload/vim_dadbod_completion/schemas.vim
+++ b/autoload/vim_dadbod_completion/schemas.vim
@@ -1,6 +1,11 @@
-let s:base_column_query = 'SELECT TABLE_NAME,COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS'
+if empty(g:completion_use_svv)
+    let s:base_column_query = 'SELECT TABLE_NAME,COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS'
+    let s:schema_query = 'SELECT TABLE_SCHEMA,TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS GROUP BY TABLE_SCHEMA,TABLE_NAME'
+else
+    let s:base_column_query = 'SELECT DISTINCT TABLE_NAME,COLUMN_NAME FROM SVV_COLUMNS'
+    let s:schema_query = 'SELECT TABLE_SCHEMA,TABLE_NAME FROM SVV_COLUMNS GROUP BY TABLE_SCHEMA,TABLE_NAME'
+endif
 let s:query = s:base_column_query.' ORDER BY COLUMN_NAME ASC'
-let s:schema_query = 'SELECT TABLE_SCHEMA,TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS GROUP BY TABLE_SCHEMA,TABLE_NAME'
 let s:count_query = 'SELECT COUNT(*) AS total FROM INFORMATION_SCHEMA.COLUMNS'
 let s:table_column_query = s:base_column_query.' WHERE TABLE_NAME={db_tbl_name}'
 let s:reserved_words = vim_dadbod_completion#reserved_keywords#get_as_dict()

--- a/doc/vim-dadbod-completion.txt
+++ b/doc/vim-dadbod-completion.txt
@@ -130,6 +130,15 @@ g:vim_dadbod_completion_source_limits
 
 		Default value: `{}`
 
+							      *g:completion_use_svv*
+g:completion_use_svv
+		Changes completion to use SVV_COLUMNS instead of INFORMATION_SCHEMA.COLUMNS. This may find tables in Redshift that INFORMATION_SCHEMA does not reach.
+>
+		let g:completion_use_svv = 1
+<
+
+		Default value: `0`
+
 --------------------------------------------------------------------------------
 COMMANDS                                          *vim-dadbod-completion-commands*
 

--- a/plugin/vim_dadbod_completion.vim
+++ b/plugin/vim_dadbod_completion.vim
@@ -3,6 +3,7 @@ if exists('g:vim_dadbod_completion_loaded')
 endif
 
 let g:vim_dadbod_completion_loaded = 1
+let g:completion_use_svv = get(g:, 'completion_use_svv', 0)
 
 augroup vim_dadbod_completion
   autocmd!


### PR DESCRIPTION
I've always noticed that my completion never found a certain schema. I think it has something to do with how that specific schema is set up on our DB but I have no idea for sure what it could be since I do have all the permissions and stuff. It turns out that INFORMATION_SCHEMA can't find information about this schema at all, in any of the tables. I wasn't able to track down an answer as to why but I did find that SVV_COLUMNS does find it.

I'm not sure if this is just me or if other Redshift users can't find tables as well. Since I've already made and use the SVV_COLUMNS modifications I decided to just create a variable that defaults to 0 and then make a pull request for you to merge if you like. :)