### PR TITLE
Add an option to complete the keywords in lower case

### DIFF
--- a/autoload/vim_dadbod_completion.vim
+++ b/autoload/vim_dadbod_completion.vim
@@ -10,7 +10,8 @@ let s:filter_rgx = printf('^\(%s\)\?', s:quotes.open)
 let s:mark = get(g:, 'vim_dadbod_completion_mark', '[DB]')
 let s:default_limit = 200
 let s:limits = get(g:, 'vim_dadbod_completion_source_limits', {})
-let s:mapped_reserved_words = map(copy(vim_dadbod_completion#reserved_keywords#get()), {i,word ->
+let s:lowercase_keywords = get(g:, 'vim_dadbod_completion_lowercase_keywords', 0)
+let s:mapped_reserved_words = map(copy(vim_dadbod_completion#reserved_keywords#get(s:lowercase_keywords)), {i,word ->
       \ {'word': word, 'abbr': word, 'menu': s:mark, 'info': 'SQL reserved word', 'kind': 'R' }
       \ })
 

--- a/autoload/vim_dadbod_completion.vim
+++ b/autoload/vim_dadbod_completion.vim
@@ -10,8 +10,7 @@ let s:filter_rgx = printf('^\(%s\)\?', s:quotes.open)
 let s:mark = get(g:, 'vim_dadbod_completion_mark', '[DB]')
 let s:default_limit = 200
 let s:limits = get(g:, 'vim_dadbod_completion_source_limits', {})
-let s:lowercase_keywords = get(g:, 'vim_dadbod_completion_lowercase_keywords', 0)
-let s:mapped_reserved_words = map(copy(vim_dadbod_completion#reserved_keywords#get(s:lowercase_keywords)), {i,word ->
+let s:mapped_reserved_words = map(copy(vim_dadbod_completion#reserved_keywords#get()), {i,word ->
       \ {'word': word, 'abbr': word, 'menu': s:mark, 'info': 'SQL reserved word', 'kind': 'R' }
       \ })
 

--- a/autoload/vim_dadbod_completion/reserved_keywords.vim
+++ b/autoload/vim_dadbod_completion/reserved_keywords.vim
@@ -147,11 +147,11 @@ let s:reserved_words = [
       \ 'WRITETEXT', 'X509', 'XOR', 'YEAR', 'YEAR_MONTH', 'ZEROFILL', 'ZONE',
       \ ]
 
-function! vim_dadbod_completion#reserved_keywords#get(...) abort
-  let l:lowercase = get(a:, 1, 0)
-  if l:lowercase == 1
-    return map(copy(s:reserved_words), {_, word -> tolower(word)})
-  endif
+if get(g:, 'vim_dadbod_completion_lowercase_keywords', 0) == 1
+  call map(s:reserved_words, {_, word -> tolower(word)})
+endif
+
+function! vim_dadbod_completion#reserved_keywords#get() abort
   return s:reserved_words
 endfunction
 

--- a/autoload/vim_dadbod_completion/reserved_keywords.vim
+++ b/autoload/vim_dadbod_completion/reserved_keywords.vim
@@ -147,7 +147,10 @@ let s:reserved_words = [
       \ 'WRITETEXT', 'X509', 'XOR', 'YEAR', 'YEAR_MONTH', 'ZEROFILL', 'ZONE',
       \ ]
 
-function! vim_dadbod_completion#reserved_keywords#get() abort
+function! vim_dadbod_completion#reserved_keywords#get(lowercase) abort
+  if a:lowercase
+    return map(s:reserved_words, {i, keyword -> tolower(keyword)})
+  endif
   return s:reserved_words
 endfunction
 

--- a/autoload/vim_dadbod_completion/reserved_keywords.vim
+++ b/autoload/vim_dadbod_completion/reserved_keywords.vim
@@ -147,9 +147,10 @@ let s:reserved_words = [
       \ 'WRITETEXT', 'X509', 'XOR', 'YEAR', 'YEAR_MONTH', 'ZEROFILL', 'ZONE',
       \ ]
 
-function! vim_dadbod_completion#reserved_keywords#get(lowercase) abort
-  if a:lowercase
-    return map(s:reserved_words, {i, keyword -> tolower(keyword)})
+function! vim_dadbod_completion#reserved_keywords#get(...) abort
+  let l:lowercase = get(a:, 1, 0)
+  if l:lowercase == 1
+    return map(copy(s:reserved_words), {_, word -> tolower(word)})
   endif
   return s:reserved_words
 endfunction

--- a/autoload/vim_dadbod_completion/schemas.vim
+++ b/autoload/vim_dadbod_completion/schemas.vim
@@ -10,6 +10,10 @@ let s:quote_rules = {
       \ 'reserved_word': {val -> has_key(s:reserved_words, toupper(val))}
       \ }
 
+if get(g:, 'vim_dadbod_completion_lowercase_keywords', 0) == 1
+  let s:quote_rules['reserved_word'] = {val -> has_key(s:reserved_words, tolower(val))}
+endif
+
 function! s:map_and_filter(delimiter, list) abort
   return filter(
         \ map(a:list, { _, table -> map(split(table, a:delimiter), 'trim(v:val)') }),

--- a/doc/vim-dadbod-completion.txt
+++ b/doc/vim-dadbod-completion.txt
@@ -130,6 +130,15 @@ g:vim_dadbod_completion_source_limits
 
 		Default value: `{}`
 
+					      *g:vim_dadbod_completion_lowercase_keywords*
+g:vim_dadbod_completion_lowercase_keywords
+		Use lower case for keywords completions. Add this to vimrc
+>
+		let vim_dadbod_completion_lowercase_keywords = 1
+<
+
+		Default value: `0`
+
 --------------------------------------------------------------------------------
 COMMANDS                                          *vim-dadbod-completion-commands*
 

--- a/doc/vim-dadbod-completion.txt
+++ b/doc/vim-dadbod-completion.txt
@@ -134,7 +134,7 @@ g:vim_dadbod_completion_source_limits
 g:vim_dadbod_completion_lowercase_keywords
 		Use lower case for keywords completions. Add this to vimrc
 >
-		let vim_dadbod_completion_lowercase_keywords = 1
+		let g:vim_dadbod_completion_lowercase_keywords = 1
 <
 
 		Default value: `0`


### PR DESCRIPTION
Add new boolean option `g:vim_dadbod_completion_lowercase_keywords` to control the case of the keyword completion.
The usual case is preserved and the lowercase parameter flag in `vim_dadbod_completion#reserved_keywords#get()` is optional to prevent breaking changes.