### PR TITLE
nvim-cmp: report kind as nvim-cmp lsp kind (to support colors and icons)

### DIFF
--- a/lua/vim_dadbod_completion.lua
+++ b/lua/vim_dadbod_completion.lua
@@ -34,6 +34,15 @@ function nvim_cmp_source:get_trigger_characters(_)
   return { '"', '`', '[', ']', '.' }
 end
 
+local map_kind_to_cmp_lsp_kind = {
+  F = 3,  -- Function -> Function
+  C = 5,  -- Column -> Field
+  A = 6,  -- Alias -> Variable
+  T = 7,  -- Table -> Class
+  R = 14, -- Reserved -> Keyword
+  S = 19, -- Schema -> Folder
+}
+
 function nvim_cmp_source:complete(params, callback)
   local input = string.sub(params.context.cursor_before_line, params.offset)
   local results = vim.fn['vim_dadbod_completion#omni'](0, input)
@@ -47,6 +56,7 @@ function nvim_cmp_source:complete(params, callback)
         description = item.menu,
       },
       documentation = item.info,
+      kind = map_kind_to_cmp_lsp_kind[item.kind],
     })
   end
 


### PR DESCRIPTION
This pr allows nvim-cmp to correctly display item kinds. Its achieved by mapping internal kinds: `F` - function, `T` - table, `C` - column, , and so on, to its lsp counterparts: function, class, field...

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/d5de4d0f-d013-4555-81b7-542763eb557d) | ![image](https://github.com/user-attachments/assets/947df67c-6556-414d-84d7-5dc81c4c2162) |
