### PR TITLE
Update the README for blink.cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ return {
     opts = {
       sources = {
         -- add vim-dadbod-completion to your completion providers
-        completion = {
-          enabled_providers = { "lsp", "path", "snippets", "buffer", "dadbod" },
-        },
+        default = { "lsp", "path", "snippets", "buffer", "dadbod" },
         providers = {
           dadbod = { name = "Dadbod", module = "vim_dadbod_completion.blink" },
         },


### PR DESCRIPTION
Sources.completion.enabled_providers has been replaced with sources.default